### PR TITLE
Fix five project creation and import bugs

### DIFF
--- a/app/Http/Controllers/ProjectsController.php
+++ b/app/Http/Controllers/ProjectsController.php
@@ -333,11 +333,20 @@ class ProjectsController extends Controller
             return redirect()->route('projects.import')->withInput()->withErrors(['reserved name']);
         }
 
+        // This clone only proves the repository is reachable; UpdateProject
+        // does the real work in a directory of its own. Anything left here by
+        // an earlier import of the same name would make git refuse to clone
+        // into a non-empty directory, so clear it out first and afterwards.
         $tempFolder = sys_get_temp_dir() . '/' . Str::slug($request->name);
+        if (is_dir($tempFolder)) {
+            Helpers::delTree($tempFolder);
+        }
 
         try {
             $repo->cloneRepository($request->git, $tempFolder, ['-q', '--single-branch', '--depth', 1]);
         } catch (GitException $e) {
+            Helpers::delTree($tempFolder);
+
             return redirect()->route('projects.import')->withInput()->withErrors([$e->getMessage()]);
         }
 
@@ -351,6 +360,8 @@ class ProjectsController extends Controller
 
             return redirect()->route('projects.import')->withInput()->withErrors([$e->getMessage()]);
         }
+
+        Helpers::delTree($tempFolder);
 
         return redirect()->route('projects.index')->withSuccesses([$project->name . ' being imported!']);
     }

--- a/app/Http/Controllers/ProjectsController.php
+++ b/app/Http/Controllers/ProjectsController.php
@@ -343,8 +343,6 @@ class ProjectsController extends Controller
 
         try {
             $project = $this->storeProjectInfo($request);
-            $project->git = $request->git;
-            $project->save();
             /** @var User $user */
             $user = Auth::user();
             UpdateProject::dispatch($project, $user);
@@ -364,10 +362,14 @@ class ProjectsController extends Controller
      */
     private function storeProjectInfo(Request $request): Project
     {
-        $project = Project::create([
-            'name' => $request->name,
-            'category_id' => $request->category_id,
-        ]);
+        $project = new Project();
+        $project->name = $request->name;
+        $project->category_id = $request->category_id;
+        // Set before the insert: Project::created only seeds an empty
+        // __init__.py for projects that are not backed by a git repository,
+        // and the clone brings its own.
+        $project->git = $request->git;
+        $project->save();
 
         if ($request->badge_ids) {
             $badges = Badge::find($request->badge_ids);

--- a/app/Http/Requests/ProjectStoreRequest.php
+++ b/app/Http/Requests/ProjectStoreRequest.php
@@ -32,9 +32,13 @@ class ProjectStoreRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name'        => 'required|unique:projects',
-            'description' => 'required|sometimes',
-            'git'         => 'required|sometimes',
+            'name' => 'required|unique:projects',
+            // The description textarea is always submitted, so "sometimes"
+            // never made it optional; an empty one just failed "required".
+            // An empty description simply means no README.md is created.
+            'description' => 'nullable|string',
+            // Only the import form posts this, and there it is mandatory.
+            'git'         => 'sometimes|required',
             'category_id' => 'required|exists:categories,id',
         ];
     }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -113,13 +113,14 @@ window.addEventListener('load', async function () {
 					language: cm.languageFor(extension),
 					keyMap: window.keymap
 				});
-				// Enable navigation prompt
+				// Warn about losing edits, but not when the edits are being
+				// saved. Use the textarea's own form: not every page that has
+				// an editor calls its form "content_form".
 				window.onbeforeunload = function () {
 					return true;
 				};
-				const form = document.getElementById('content_form');
-				if (form) {
-					form.addEventListener('submit', function () {
+				if (editable.form) {
+					editable.form.addEventListener('submit', function () {
 						window.onbeforeunload = null;
 					});
 				}

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -49,7 +49,7 @@
                                 @else
 
                                 <div class="form-group @if($errors->has('description')) has-error @endif">
-                                    {{ Form::label('description', 'Description', ['class' => 'control-label']) }} (markdown)
+                                    {{ Form::label('description', 'Description', ['class' => 'control-label']) }} (optional, markdown)
                                     {{ Form::textarea('description', null, ['class' => 'form-control', 'id' => 'content']) }}
                                     {{ Form::hidden('extension', 'md', ['id' => 'extension']) }}
                                 </div>

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -64,6 +64,8 @@
                             {!! $project->descriptionHtml !!}
                         </div>
                         <div class="col-md-4 clearfix">
+                            <strong>Type: {{ \App\Models\Badge::$types[$project->project_type] ?? $project->project_type }}</strong>
+                            <hr>
                             <strong>Category: {{ $project->category }}</strong>
                             <hr>
                             <strong>Status: {{ $project->status }}</strong>

--- a/tests/Feature/ProjectsGitTest.php
+++ b/tests/Feature/ProjectsGitTest.php
@@ -87,6 +87,69 @@ class ProjectsGitTest extends TestCase
         Helpers::delTree($folder);
     }
 
+    /**
+     * A git backed project must not get the seeded empty __init__.py: the
+     * clone brings its own, and FilePolicy forbids deleting files from a git
+     * project, so the duplicate could never be removed.
+     */
+    public function testProjectsImportGitHasNoSeededInitFile(): void
+    {
+        $name = $this->faker->name;
+        $folder = sys_get_temp_dir() . '/' . Str::slug($name, '_');
+        mkdir($folder);
+
+        $hash = $this->faker->sha1;
+        $mockRepo = $this->mock(GitRepository::class);
+        $mockRepo->expects('getLastCommitId')->twice()->andReturns(new CommitId($hash));
+        $this->app->instance(GitRepository::class, $mockRepo);
+        $mockGit = $this->mock(Git::class);
+        $mockGit->expects('cloneRepository')->twice()->andReturns($mockRepo);
+        $this->app->instance(Git::class, $mockGit);
+        /** @var User $user */
+        $user = User::factory()->create();
+        /** @var Category $category */
+        $category = Category::factory()->create();
+
+        $this->actingAs($user)->call(
+            'post',
+            '/import-git',
+            ['name' => $name, 'git' => $this->faker->url, 'category_id' => $category->id, 'status' => 'unknown']
+        );
+
+        /** @var Project $project */
+        $project = Project::get()->last();
+        $this->assertNotNull($project->git);
+        /** @var Version $version */
+        $version = $project->versions->last();
+        $this->assertCount(0, $version->files()->where('name', '__init__.py')->get());
+
+        Helpers::delTree($folder);
+    }
+
+    /**
+     * A project without a git repository still gets its empty __init__.py.
+     */
+    public function testProjectsStoreWithoutGitKeepsInitFile(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        /** @var Category $category */
+        $category = Category::factory()->create();
+
+        $this->actingAs($user)->call(
+            'post',
+            '/projects',
+            ['name' => $this->faker->name, 'category_id' => $category->id, 'status' => 'unknown']
+        );
+
+        /** @var Project $project */
+        $project = Project::get()->last();
+        $this->assertNull($project->git);
+        /** @var Version $version */
+        $version = $project->versions->last();
+        $this->assertCount(1, $version->files()->where('name', '__init__.py')->get());
+    }
+
     public function testProjectsStoreGitTooLong(): void
     {
         $name = $this->faker->name;

--- a/tests/Feature/ProjectsGitTest.php
+++ b/tests/Feature/ProjectsGitTest.php
@@ -150,6 +150,47 @@ class ProjectsGitTest extends TestCase
         $this->assertCount(1, $version->files()->where('name', '__init__.py')->get());
     }
 
+    /**
+     * The import clone directory is keyed on the project name, so a leftover
+     * from an earlier import of that name made git refuse to clone and the
+     * user saw a temp directory error (#102).
+     */
+    public function testProjectsImportGitClearsStaleTempFolder(): void
+    {
+        $name = $this->faker->name;
+        $importFolder = sys_get_temp_dir() . '/' . Str::slug($name);
+        $updateFolder = sys_get_temp_dir() . '/' . Str::slug($name, '_');
+        mkdir($updateFolder);
+
+        // Left behind by an earlier import of the same name.
+        mkdir($importFolder);
+        file_put_contents($importFolder . '/leftover.txt', 'stale');
+
+        $hash = $this->faker->sha1;
+        $mockRepo = $this->mock(GitRepository::class);
+        $mockRepo->expects('getLastCommitId')->twice()->andReturns(new CommitId($hash));
+        $this->app->instance(GitRepository::class, $mockRepo);
+        $mockGit = $this->mock(Git::class);
+        $mockGit->expects('cloneRepository')->twice()->andReturns($mockRepo);
+        $this->app->instance(Git::class, $mockGit);
+        /** @var User $user */
+        $user = User::factory()->create();
+        /** @var Category $category */
+        $category = Category::factory()->create();
+
+        $response = $this->actingAs($user)->call(
+            'post',
+            '/import-git',
+            ['name' => $name, 'git' => $this->faker->url, 'category_id' => $category->id, 'status' => 'unknown']
+        );
+
+        $response->assertRedirect('/projects/')->assertSessionHas('successes');
+        // Cleared before cloning, and not left behind for the next import.
+        $this->assertDirectoryDoesNotExist($importFolder);
+
+        Helpers::delTree($updateFolder);
+    }
+
     public function testProjectsStoreGitTooLong(): void
     {
         $name = $this->faker->name;

--- a/tests/Feature/ProjectsTest.php
+++ b/tests/Feature/ProjectsTest.php
@@ -96,6 +96,38 @@ class ProjectsTest extends TestCase
     /**
      * Check the projects can be stored.
      */
+    /**
+     * An empty description is allowed; it just means no README.md is written.
+     */
+    public function testProjectsStoreWithoutDescription(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        /** @var Category $category */
+        $category = Category::factory()->create();
+
+        $response = $this
+            ->actingAs($user)
+            ->call(
+                'post',
+                '/projects',
+                [
+                    'name'        => $this->faker->name,
+                    'description' => '',
+                    'category_id' => $category->id,
+                    'status'      => 'unknown',
+                ]
+            );
+
+        $response->assertSessionHasNoErrors();
+        /** @var Project $project */
+        $project = Project::get()->last();
+        $response->assertRedirect('/projects/' . $project->slug . '/edit');
+        /** @var Version $version */
+        $version = $project->versions->last();
+        $this->assertCount(0, $version->files()->where('name', 'README.md')->get());
+    }
+
     public function testProjectsStore(): void
     {
         /** @var User $user */
@@ -657,6 +689,26 @@ class ProjectsTest extends TestCase
         $response = $this
             ->call('get', '/projects/' . $project->slug);
         $response->assertStatus(200)->assertViewHas(['project']);
+    }
+
+    /**
+     * The badge menu is organised by type first, so the detail page has to say
+     * whether an egg is micropython, ESP32 or FPGA.
+     */
+    public function testProjectsViewShowsType(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $this->be($user);
+
+        foreach (Badge::$types as $type => $label) {
+            /** @var Project $project */
+            $project = Project::factory()->create(['project_type' => $type]);
+
+            $this->call('get', '/projects/' . $project->slug)
+                ->assertStatus(200)
+                ->assertSee($label);
+        }
     }
 
     /**

--- a/tests/e2e/editor.spec.js
+++ b/tests/e2e/editor.spec.js
@@ -123,3 +123,38 @@ test.describe('asset loading', () => {
 		expect(errors).toEqual([]);
 	});
 });
+
+test.describe('unsaved changes warning', () => {
+	// The listener that clears window.onbeforeunload used to be attached to a
+	// hardcoded #content_form, which the new project form does not have, so
+	// saving a new egg always warned about losing changes.
+	test('clears the warning when the new project form is submitted', async ({ page }) => {
+		await login(page);
+		await page.goto('/projects/create');
+		await page.waitForSelector('.cm-editor');
+
+		expect(await page.evaluate(() => typeof window.onbeforeunload)).toBe('function');
+
+		await page.evaluate(() => {
+			const form = document.querySelector('textarea#content').form;
+			form.addEventListener('submit', (e) => e.preventDefault(), { once: true });
+			form.requestSubmit();
+		});
+
+		expect(await page.evaluate(() => window.onbeforeunload)).toBeNull();
+	});
+
+	test('clears the warning when a file is saved', async ({ page }) => {
+		await login(page);
+		await page.goto(await readmeEditUrl(page));
+		await page.waitForSelector('.cm-editor');
+
+		await page.evaluate(() => {
+			const form = document.querySelector('textarea#content').form;
+			form.addEventListener('submit', (e) => e.preventDefault(), { once: true });
+			form.requestSubmit();
+		});
+
+		expect(await page.evaluate(() => window.onbeforeunload)).toBeNull();
+	});
+});


### PR DESCRIPTION
Five reported bugs, one commit each, each with the root cause found in the code
rather than guessed at. Closes **#158**, **#101**, **#162**, **#129**, **#159**
and **#102**.

250 PHP tests (5 new), 26 JS tests, 10 browser tests (2 new), phpstan level 8 and
phpcs all pass.

---

### #158 — "Changes may not be saved" when saving a new egg

`app.js` clears `window.onbeforeunload` when the form around the editor is
submitted, but it found that form by the hardcoded id `content_form`. The new
project form does not have that id, so on `/projects/create` the listener was
never attached and every save warned about losing changes.

Now it uses the textarea's own `.form`, so it works whatever the form is called.
Covered by a browser test that fails on the old code and passes on the new.

### #101 + #162 — duplicate `__init__.py` after importing from git

`storeProjectInfo()` created the Project while `git` was still `null`, so
`Project::created` seeded the empty `__init__.py` that non-git projects get.
`git` was only assigned *afterwards*. The clone then brought its own
`__init__.py`, so the project had two.

That is also the second half of #162: the delete button was not missing by
accident, `FilePolicy::delete` deliberately refuses to remove files from a git
backed project — so the duplicate could never be deleted. Fixing the cause fixes
both, and the policy is left alone.

`git` is assigned before the insert now. Projects without a repository still get
their `__init__.py`; there is a test for each case.

### #129 — description should be optional

The rule was `'required|sometimes'`. `sometimes` only skips validation when a
field is **absent**, and the description textarea is always submitted, so an
empty description hit `required` and the form errored — which is exactly the
report.

Now `'nullable|string'`. `storeProjectInfo()` already skipped writing `README.md`
for an empty description, so an egg without one simply has no README.

`git` keeps its rule but is now spelled `'sometimes|required'`, which reads the
way it actually behaves: only the import form posts it, and there it is
mandatory.

### #159 — no way to tell an egg's type

The badge menu is organised by type first and category second, but `project_type`
only appeared in the JSON-LD block, never on screen. It is now shown above the
category using the human readable label from `Badge::$types` ("Micropython eggs",
"ESP32 native binaries", "ICE40 FPGA bitstreams").

### #102 — cannot re-import an egg with a name used before

Not the slug: `destroy()` already renames a project to `Deleted <rand> <name>`
before soft-deleting, so the slug is freed.

It is the temp directory, which is what the reported error actually said.
`import()` clones into `sys_get_temp_dir()/<name slugged with dashes>` purely to
prove the repository is reachable, while `UpdateProject` does the real work in
`<slug with underscores>`. Nothing ever removed the first directory on a
successful import, so importing the same name again hit a non-empty target and
git refused. Deleting the project did not help, because the leftover is keyed on
the name, not the project.

It is now cleared before cloning and again once the import is under way.

---

### Not touched here

- **#156** (password reset 500) and **#163** / **#160** (419s) need a production
  stack trace. I tried to reproduce both locally, including with
  `APP_ENV=production` and an unreachable SMTP host; the reset returns 302, not
  500. Guessing at CSRF config would be shotgun debugging — a Sentry event would
  settle either in minutes.
- **#127** (16 MB uploads) looks like configuration, not code: Dropzone already
  allows 32 MB and there is no server-side `max` rule, so it is `post_max_size` /
  `upload_max_filesize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
