### PR TITLE
Free text licences and a stable egg archive URL

### DIFF
--- a/app/Http/Controllers/MchController.php
+++ b/app/Http/Controllers/MchController.php
@@ -12,6 +12,7 @@ use App\Models\Version;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class MchController extends Controller
 {
@@ -268,6 +269,79 @@ class MchController extends Controller
             ['Content-Type' => 'application/json'],
             JSON_UNESCAPED_SLASHES
         );
+    }
+
+    /**
+     * Download the published egg archive.
+     *
+     * @param string $device
+     * @param string $type
+     * @param string $category
+     * @param string $app
+     *
+     * @return BinaryFileResponse|JsonResponse
+     */
+    #[OA\Get(
+        path: '/v2/{device}/{type}/{category}/{app}.tar.gz',
+        tags: ['MCH2022'],
+        parameters: [
+            new OA\Parameter(
+                name: 'device',
+                in: 'path',
+                required: true,
+                schema: new OA\Schema(type: 'string', format: 'slug', example: 'mch2022'),
+            ),
+            new OA\Parameter(
+                name: 'type',
+                in: 'path',
+                required: true,
+                schema: new OA\Schema(type: 'string', format: 'slug', example: 'esp32'),
+            ),
+            new OA\Parameter(
+                name: 'category',
+                in: 'path',
+                required: true,
+                schema: new OA\Schema(type: 'string', format: 'slug', example: 'fun'),
+            ),
+            new OA\Parameter(
+                name: 'app',
+                in: 'path',
+                required: true,
+                schema: new OA\Schema(type: 'string', format: 'slug', example: 'game_of_life'),
+            ),
+        ],
+        responses: [
+            new OA\Response(response: 'default', ref: '#/components/responses/undocumented'),
+        ],
+    )]
+    public function archive(
+        string $device,
+        string $type,
+        string $category,
+        string $app
+    ): BinaryFileResponse|JsonResponse {
+        /** @var Badge $badge */
+        $badge = Badge::whereSlug($device)->firstOrFail();
+        $categoryId = Category::whereSlug($category)->firstOrFail()->id;
+        /** @var Project $project */
+        $project = $badge->projects()
+            ->whereProjectType($type)->whereCategoryId($categoryId)->whereSlug($app)->firstOrFail();
+
+        /** @var Version|null $version */
+        $version = $project->versions()->published()->get()->last();
+        if ($version === null || $version->zip === null) {
+            return response()->json(['message' => 'No published release'], 404);
+        }
+
+        $path = public_path($version->zip);
+        if (!is_file($path)) {
+            // Published, but the archive is gone from disk.
+            return response()->json(['message' => 'No published release'], 404);
+        }
+
+        return response()->download($path, $project->slug . '.tar.gz', [
+            'Content-Type' => 'application/gzip',
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/ProjectsController.php
+++ b/app/Http/Controllers/ProjectsController.php
@@ -15,7 +15,6 @@ use App\Models\Badge;
 use App\Models\BadgeProject;
 use App\Models\Category;
 use App\Models\File;
-use App\Models\License;
 use App\Models\Project;
 use App\Models\User;
 use App\Models\Version;
@@ -412,11 +411,11 @@ class ProjectsController extends Controller
      */
     private function manageLicense(Project $project, Request $request): void
     {
-        if ($request->license) {
-            if (!License::where('licenseId', $request->license)->exists()) {
-                throw new \RuntimeException('Unknown license');
-            }
-            $project->license = $request->license;
+        if ($request->has('license')) {
+            // Any licence is allowed, not just the SPDX list: people are free
+            // to pick a proprietary one. Known SPDX identifiers still get a
+            // name and a link, the rest are shown verbatim.
+            $project->license = trim((string) $request->license);
             $project->save();
         }
     }

--- a/app/Http/Middleware/AddContentLength.php
+++ b/app/Http/Middleware/AddContentLength.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Http\Response;
 
 class AddContentLength
 {
@@ -18,6 +19,13 @@ class AddContentLength
     public function handle($request, Closure $next)
     {
         $response = $next($request);
+
+        // Only ordinary responses have content() to measure. File downloads
+        // set their own Content-Length, and a streamed response does not know
+        // its length up front; asking either for content() is fatal.
+        if (!$response instanceof Response) {
+            return $response;
+        }
 
         // to be sure nothing was already output (by an echo statement or something)
         if (headers_sent() || ob_get_contents() !== '') {
@@ -48,7 +56,7 @@ class AddContentLength
 //        }
 
         // compressed or not, sets the Content-Length
-        $response->header('Content-Length', $contentLength);
+        $response->header('Content-Length', (string) $contentLength);
 
         return $response;
     }

--- a/app/Http/Requests/ProjectStoreRequest.php
+++ b/app/Http/Requests/ProjectStoreRequest.php
@@ -40,6 +40,9 @@ class ProjectStoreRequest extends FormRequest
             // Only the import form posts this, and there it is mandatory.
             'git'         => 'sometimes|required',
             'category_id' => 'required|exists:categories,id',
+            // Free text: an SPDX identifier gets a name and a link, anything
+            // else is shown as typed.
+            'license' => 'nullable|string|max:255',
         ];
     }
 }

--- a/app/Http/Requests/ProjectUpdateRequest.php
+++ b/app/Http/Requests/ProjectUpdateRequest.php
@@ -34,6 +34,7 @@ class ProjectUpdateRequest extends FormRequest
         return [
             'min_firmware' => 'nullable|integer',
             'max_firmware' => 'nullable|integer',
+            'license'      => 'nullable|string|max:255',
         ];
     }
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -579,8 +579,11 @@ class Project extends Model
         /** @var License|null $license */
         $license = License::where('LicenseId', $this->license)->first();
         if ($license === null) {
-            return $this->license ;
+            // A licence that is not an SPDX identifier has no reference to
+            // link to; returning the raw text here would emit it as a URL.
+            return '';
         }
+
         return $license->reference;
     }
 }

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -55,10 +55,7 @@
                                 </div>
                                 @endif
 
-                                <div class="form-group @if($errors->has('license')) has-error @endif">
-                                    {{ Form::label('license', 'License', ['class' => 'control-label']) }}
-                                    {{ Form::select('license', \App\Models\License::where('isDeprecatedLicenseId', 0)->where('isOsiApproved', 1)->pluck('name', 'licenseId'), 'MIT', ['class' => 'form-control', 'id' => 'license']) }}
-                                </div>
+                                @include('projects.partials.license')
 
                                 <div class="form-group @if($errors->has('allow_team_fixes')) has-error @endif">
                                     {{ Form::label('allow_team_fixes', 'Allow badge.team to apply fixes to code', ['class' => 'control-label']) }}

--- a/resources/views/projects/edit.blade.php
+++ b/resources/views/projects/edit.blade.php
@@ -55,10 +55,7 @@
                                 {{ Form::label('project_type', 'Type', ['class' => 'control-label']) }}
                                 {{ Form::select('project_type', \App\Models\Badge::$types, $project->project_type, ['class' => 'form-control', 'id' => 'badge_ids']) }}
                             </div>
-                            <div class="form-group @if($errors->has('license')) has-error @endif">
-                                {{ Form::label('license', 'License', ['class' => 'control-label']) }}
-                                {{ Form::select('license', \App\Models\License::where('isDeprecatedLicenseId', 0)->where('isOsiApproved', 1)->pluck('name', 'licenseId'), $project->license, ['class' => 'form-control', 'id' => 'license']) }}
-                            </div>
+                            @include('projects.partials.license')
                             <div class="form-group @if($errors->has('min_firmware') || $errors->has('max_firmware')) has-error @endif">
                                 {{ Form::label('min_firmware', 'Minimal firmware version', ['class' => 'control-label']) }}
                                 {{ Form::text('min_firmware', $project->min_firmware, ['class' => 'form-control', 'id' => 'min_firmware']) }}

--- a/resources/views/projects/partials/license.blade.php
+++ b/resources/views/projects/partials/license.blade.php
@@ -1,0 +1,28 @@
+@php
+    /** @var \App\Models\Project|null $project */
+    $currentLicense = isset($project) ? $project->license : 'MIT';
+@endphp
+<div class="form-group @if($errors->has('license')) has-error @endif">
+    {{ Form::label('license', 'License', ['class' => 'control-label']) }}
+    {{ Form::text('license', $currentLicense, [
+        'class'       => 'form-control',
+        'id'          => 'license',
+        'list'        => 'spdx-licenses',
+        'maxlength'   => 255,
+        'placeholder' => 'MIT, GPL-3.0-or-later, Proprietary, ...',
+    ]) }}
+    <span class="help-block">
+        Anything you like. The suggestions are
+        <a href="https://spdx.org/licenses/" target="_blank" rel="noopener">SPDX identifiers</a>;
+        pick one of those and the site can link to the licence text. Leave it empty for
+        &ldquo;all rights reserved&rdquo;.
+    </span>
+    <datalist id="spdx-licenses">
+        @foreach(\App\Models\License::where('isDeprecatedLicenseId', 0)->orderBy('licenseId')->get() as $spdx)
+            <option value="{{ $spdx->licenseId }}">{{ $spdx->name }}</option>
+        @endforeach
+    </datalist>
+    @if ($errors->has('license'))
+        <span class="help-block"><strong>{{ $errors->first('license') }}</strong></span>
+    @endif
+</div>

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -68,6 +68,14 @@
                             <hr>
                             <strong>Category: {{ $project->category }}</strong>
                             <hr>
+                            <strong>License:
+                                @if($project->license_url)
+                                    <a href="{{ $project->license_url }}" target="_blank" rel="noopener">{{ $project->license_name }}</a>
+                                @else
+                                    {{ $project->license_name }}
+                                @endif
+                            </strong>
+                            <hr>
                             <strong>Status: {{ $project->status }}</strong>
                             <hr>
                             @if($project->min_firmware)

--- a/routes/mch2022.php
+++ b/routes/mch2022.php
@@ -9,9 +9,13 @@ Route::get('devices', [MchController::class, 'devices']);
 Route::get('{device}/types', [MchController::class, 'types']);
 Route::get('{device}/{type}/categories', [MchController::class, 'categories']);
 Route::get('{device}/{type}/{category}', [MchController::class, 'apps']);
+// Before the {app} route, which would otherwise swallow the .tar.gz suffix.
+Route::get('{device}/{type}/{category}/{app}.tar.gz', [MchController::class, 'archive'])
+    ->where('app', '[A-Za-z0-9_-]+')
+    ->name('mch.archive');
+
 Route::get('{device}/{type}/{category}/{app}', [MchController::class, 'app']);
 
-//Route::get('{device}/{type}/{category}/{app}/zip', [MchController::class, 'zip']);
 //Route::get('{device}/{type}/{category}/{app}/icon', [MchController::class, 'icon']);
 
 Route::get('{device}/{type}/{category}/{app}/{file}', [MchController::class, 'file'])->name('mch.file');

--- a/tests/Feature/Mch20222Test.php
+++ b/tests/Feature/Mch20222Test.php
@@ -121,6 +121,68 @@ class Mch20222Test extends TestCase
     }
 
     /**
+     * The published egg archive under a stable, guessable URL (#137).
+     */
+    public function testMchArchive(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $this->be($user);
+
+        /** @var Badge $badge */
+        $badge = Badge::factory()->create();
+        /** @var Version $version */
+        $version = Version::factory()->create();
+        $version->project->badges()->attach($badge);
+        /** @var Category $category */
+        $category = $version->project->category()->first();
+
+        $base = '/v2/' . $badge->slug . '/python/' . $category->slug . '/' . $version->project->slug;
+
+        // Nothing published yet.
+        $this->json('GET', $base . '.tar.gz')->assertStatus(404);
+
+        // Published, but the archive is not on disk.
+        $version->zip = 'eggs/missing_egg.tar.gz';
+        $version->save();
+        $this->json('GET', $base . '.tar.gz')->assertStatus(404);
+
+        // Published and present.
+        $relative = 'eggs/' . $version->project->slug . '_test.tar.gz';
+        $path = public_path($relative);
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), 0755, true);
+        }
+        file_put_contents($path, gzencode('not really a tar, but bytes are bytes'));
+        $version->zip = $relative;
+        $version->save();
+
+        $response = $this->call('GET', $base . '.tar.gz');
+        $response->assertStatus(200);
+        $this->assertEquals('application/gzip', $response->headers->get('Content-Type'));
+        $this->assertStringContainsString(
+            $version->project->slug . '.tar.gz',
+            (string) $response->headers->get('Content-Disposition')
+        );
+
+        unlink($path);
+    }
+
+    /**
+     * An unknown egg has no archive either.
+     */
+    public function testMchArchiveUnknownApp(): void
+    {
+        /** @var Badge $badge */
+        $badge = Badge::factory()->create();
+        /** @var Category $category */
+        $category = Category::factory()->create();
+
+        $this->json('GET', '/v2/' . $badge->slug . '/python/' . $category->slug . '/nope.tar.gz')
+            ->assertStatus(404);
+    }
+
+    /**
      * Check JSON files / app info request . .
      */
     public function testMchApps(): void

--- a/tests/Feature/ProjectsTest.php
+++ b/tests/Feature/ProjectsTest.php
@@ -679,6 +679,100 @@ class ProjectsTest extends TestCase
     /**
      * Check the projects can be viewed (publicly).
      */
+    /**
+     * Licences are free text now: an SPDX identifier still resolves to a name
+     * and a link, anything else is kept and shown as typed (#176).
+     */
+    public function testProjectsStoreWithNonSpdxLicense(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        /** @var Category $category */
+        $category = Category::factory()->create();
+
+        $response = $this
+            ->actingAs($user)
+            ->call(
+                'post',
+                '/projects',
+                [
+                    'name'        => $this->faker->name,
+                    'category_id' => $category->id,
+                    'license'     => 'All rights reserved, ask me nicely',
+                    'status'      => 'unknown',
+                ]
+            );
+
+        $response->assertSessionHasNoErrors();
+        /** @var Project $project */
+        $project = Project::get()->last();
+        $this->assertEquals('All rights reserved, ask me nicely', $project->license);
+        $this->assertEquals('All rights reserved, ask me nicely', $project->license_name);
+        // Not an SPDX identifier, so there is nothing to link to.
+        $this->assertEquals('', $project->license_url);
+    }
+
+    public function testProjectsStoreWithSpdxLicenseKeepsNameAndUrl(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        /** @var Category $category */
+        $category = Category::factory()->create();
+
+        $this->actingAs($user)->call(
+            'post',
+            '/projects',
+            [
+                'name'        => $this->faker->name,
+                'category_id' => $category->id,
+                'license'     => 'MIT',
+                'status'      => 'unknown',
+            ]
+        );
+
+        /** @var Project $project */
+        $project = Project::get()->last();
+        $this->assertEquals('MIT License', $project->license_name);
+        $this->assertNotEmpty($project->license_url);
+    }
+
+    public function testProjectsUpdateAcceptsFreeTextLicense(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $this->be($user);
+        /** @var Project $project */
+        $project = Project::factory()->create(['user_id' => $user->id]);
+
+        $response = $this
+            ->actingAs($user)
+            ->call(
+                'put',
+                '/projects/' . $project->slug,
+                [
+                    'category_id' => $project->category_id,
+                    'license'     => 'WTFPL-ish',
+                ]
+            );
+
+        $response->assertSessionHasNoErrors();
+        $project->refresh();
+        $this->assertEquals('WTFPL-ish', $project->license);
+    }
+
+    public function testProjectsViewShowsLicense(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $this->be($user);
+        /** @var Project $project */
+        $project = Project::factory()->create(['license' => 'Proprietary, contact us']);
+
+        $this->call('get', '/projects/' . $project->slug)
+            ->assertStatus(200)
+            ->assertSee('Proprietary, contact us');
+    }
+
     public function testProjectsView(): void
     {
         /** @var User $user */


### PR DESCRIPTION
Two Tier B issues plus one bug they uncovered. Closes #176, closes #137.

256 PHP tests (6 new), 26 JS tests, 10 browser tests, phpstan level 8 and phpcs
all pass.

---

## #176 — licences are free text now

The field was a `select` limited to OSI approved, non-deprecated SPDX
identifiers, and `manageLicense()` threw `RuntimeException('Unknown license')`
for anything else — so a proprietary or custom licence could not be recorded at
all, which is exactly what the issue asked for.

It is a text input with the non-deprecated SPDX list attached as a `<datalist>`
(458 entries), so the identifiers are still one keystroke away without being
mandatory. A recognised identifier keeps its full name and a link to the licence
text; anything else is stored and shown as typed. An empty field still means
"all rights reserved" — `getLicenseNameAttribute()` already reported that as
*Commercial*.

Two things came with it:

- `getLicenseUrlAttribute()` fell back to returning the raw licence string when
  it was not an SPDX identifier. Harmless while only identifiers could be
  stored, but with free text it would emit prose into the JSON-LD `license`
  field and into `href` attributes. It returns an empty string now.
- The licence is **shown** on the project page. It only ever existed in the
  JSON-LD block, so you could set one and never see it — which makes a free text
  field fairly pointless.

The form is one partial now instead of being duplicated across create and edit.

## #137 — `/v2/{device}/{type}/{category}/{app}.tar.gz`

The only way to fetch an egg was the path in `Version->zip`, which carries a
`uniqid`, so a client had to read `list/json` first just to find out where the
archive lives. The new route streams the latest published archive directly, and
404s with a JSON body when nothing is published or the file has gone from disk.

It has to be registered *before* the `{app}` route, which would otherwise
swallow the suffix.

**Named `.tar.gz`, not `.zip`.** `PublishProject` builds a `PharData` tar
compressed with gzip. Serving that from a `.zip` URL would misdescribe it to
every client that trusts the extension, and building a real zip would mean a
second packaging path the badge firmware may not read. Flagging it here in case
something out there is already asking for `.zip` — easy to add an alias if so.

## Bug this uncovered

`AddContentLength` called `$response->content()` on **everything**. Only
`Illuminate\Http\Response` has that method, so any `BinaryFileResponse` or
`StreamedResponse` died with `Call to undefined method ...::content()`.

Nothing hit it before because every download built a plain response from a
string in memory — but Laravel's own `storage/{path}` route returns a
`BinaryFileResponse`, so that route was already broken on this deployment, and
the new archive endpoint 500'd until this was fixed.

It now skips anything that is not an ordinary `Response`: file responses set
their own `Content-Length`, and a streamed response cannot know its length up
front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
