### PR TITLE
Resize uploaded badge icons instead of ignoring them

### DIFF
--- a/app/Jobs/PublishProject.php
+++ b/app/Jobs/PublishProject.php
@@ -12,6 +12,7 @@ use App\Models\File;
 use App\Models\Project;
 use App\Models\User;
 use App\Models\Version;
+use App\Support\Icon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -104,7 +105,7 @@ class PublishProject implements ShouldQueue
         ];
 
         if ($this->project->hasValidIcon()) {
-            $data['icon'] = 'icon.png';
+            $data['icon'] = Icon::NAME;
         }
 
         $zip[$this->project->slug . '/metadata.json'] = (string) json_encode($data);

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Support\Helpers;
+use App\Support\Icon;
 use Database\Factories\FileFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -16,7 +17,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Image;
 
 /**
  * Class File.
@@ -186,6 +186,21 @@ class File extends Model
                 }
             }
         );
+
+        static::saving(
+            function ($file) {
+                // A badge wants icon.png at exactly 32 by 32. Scale whatever
+                // was uploaded instead of quietly dropping it from the egg.
+                if (!Icon::isIconName((string) $file->name) || !$file->isDirty('content')) {
+                    return;
+                }
+
+                $resized = Icon::normalise((string) $file->content);
+                if ($resized !== null) {
+                    $file->content = $resized;
+                }
+            }
+        );
     }
 
     /**
@@ -309,33 +324,7 @@ class File extends Model
             return false;
         }
 
-        $content = (string) $this->content;
-
-        // Uploads store raw bytes, but content may also be kept base64 encoded.
-        $dimensions = self::imageDimensions($content)
-            ?? self::imageDimensions((string) base64_decode($content, true));
-
-        return $dimensions === [32, 32];
-    }
-
-    /**
-     * Read the dimensions of image data, or null when it cannot be decoded.
-     *
-     * @param string $data
-     *
-     * @return array{0: int, 1: int}|null
-     */
-    private static function imageDimensions(string $data): ?array
-    {
-        if ($data === '') {
-            return null;
-        }
-
-        try {
-            return Image::fromBytes($data)->dimensions();
-        } catch (\Throwable) {
-            return null;
-        }
+        return Icon::dimensions((string) $this->content) === [Icon::SIZE, Icon::SIZE];
     }
 
     /**

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Support\Helpers;
+use App\Support\Icon;
 use Database\Factories\ProjectFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -484,7 +485,7 @@ class Project extends Model
         /** @var Version $version */
         $version = $this->versions->last();
         /** @var File|null $file */
-        $file = $version->files()->where('name', 'icon.png')->get()->last();
+        $file = $version->files()->where('name', Icon::NAME)->get()->last();
         if ($file === null) {
             return false;
         }

--- a/app/Support/Icon.php
+++ b/app/Support/Icon.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2017 - 2026 Badge.Team contributors
+// SPDX-License-Identifier: MIT
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\Image;
+
+/**
+ * Badge icons.
+ *
+ * A badge expects icon.png to be exactly 32 by 32 pixels, so anything else is
+ * scaled to fit and padded out with transparency rather than being rejected.
+ *
+ * @author annejan@badge.team
+ */
+class Icon
+{
+    /** The file name a badge looks for. */
+    public const NAME = 'icon.png';
+
+    /** Badge icons are square, this many pixels a side. */
+    public const SIZE = 32;
+
+    /**
+     * Fully transparent padding.
+     *
+     * contain() fills the leftover space with this. It has to be given as a
+     * colour with an alpha channel: the driver rejects the word "transparent",
+     * and leaving it out pads with opaque black.
+     */
+    private const TRANSPARENT = '#00000000';
+
+    /**
+     * Is this file the icon a badge looks for?
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public static function isIconName(string $name): bool
+    {
+        return strtolower($name) === self::NAME;
+    }
+
+    /**
+     * Read the dimensions of image data, or null when it cannot be decoded.
+     *
+     * @param string $data
+     *
+     * @return array{0: int, 1: int}|null
+     */
+    public static function dimensions(string $data): ?array
+    {
+        $decoded = self::decode($data);
+        if ($decoded === null) {
+            return null;
+        }
+
+        try {
+            return Image::fromBytes($decoded)->dimensions();
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Scale image data to a 32 by 32 PNG, keeping its aspect ratio and any
+     * transparency it had.
+     *
+     * Returns null when the data is not an image, or is already exactly what
+     * a badge wants, so callers can leave the stored bytes alone.
+     *
+     * @param string $data
+     *
+     * @return string|null
+     */
+    public static function normalise(string $data): ?string
+    {
+        $decoded = self::decode($data);
+        if ($decoded === null) {
+            return null;
+        }
+
+        $dimensions = self::dimensions($decoded);
+        if ($dimensions === null) {
+            return null;
+        }
+
+        if ($dimensions === [self::SIZE, self::SIZE] && self::isPng($decoded)) {
+            return null;
+        }
+
+        try {
+            return Image::fromBytes($decoded)
+                ->contain(self::SIZE, self::SIZE, self::TRANSPARENT)
+                ->toPng()
+                ->toBytes();
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * File content is normally raw bytes, but may also be stored base64
+     * encoded. Return the raw bytes either way, or null if it is not an image.
+     *
+     * @param string $data
+     *
+     * @return string|null
+     */
+    private static function decode(string $data): ?string
+    {
+        if ($data === '') {
+            return null;
+        }
+
+        if (self::looksLikeImage($data)) {
+            return $data;
+        }
+
+        $decoded = base64_decode($data, true);
+        if ($decoded !== false && self::looksLikeImage($decoded)) {
+            return $decoded;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $data
+     *
+     * @return bool
+     */
+    private static function looksLikeImage(string $data): bool
+    {
+        return self::isPng($data)
+            || str_starts_with($data, "\xFF\xD8\xFF")           // jpeg
+            || str_starts_with($data, 'GIF8')                   // gif
+            || str_starts_with($data, 'BM');                    // bmp
+    }
+
+    /**
+     * @param string $data
+     *
+     * @return bool
+     */
+    private static function isPng(string $data): bool
+    {
+        return str_starts_with($data, "\x89PNG\r\n\x1A\n");
+    }
+}

--- a/tests/Feature/FilesTest.php
+++ b/tests/Feature/FilesTest.php
@@ -11,6 +11,7 @@ use App\Models\File;
 use App\Models\Project;
 use App\Models\User;
 use App\Models\Version;
+use App\Support\Icon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\UploadedFile;
@@ -53,6 +54,67 @@ class FilesTest extends TestCase
         /** @var File $file */
         $file = File::where('name', '!=', '__init__.py')->first();
         $this->assertEquals($name, $file->name);
+    }
+
+    /**
+     * A badge needs icon.png at exactly 32 by 32, so an upload of any other
+     * size is scaled to fit rather than silently left out of the egg (#126).
+     */
+    public function testUploadIconIsResizedToBadgeSize(): void
+    {
+        $stub = __DIR__ . '/heart.png';
+        $path = sys_get_temp_dir() . '/' . Str::random(8) . '.png';
+        copy($stub, $path);
+
+        // The fixture is deliberately not 32 by 32.
+        $this->assertNotEquals([Icon::SIZE, Icon::SIZE], Icon::dimensions((string) file_get_contents($stub)));
+
+        $upload = new UploadedFile($path, Icon::NAME, 'image/png', null, true);
+        /** @var User $user */
+        $user = User::factory()->create();
+        $this->be($user);
+        /** @var Project $project */
+        $project = Project::factory()->create();
+        /** @var Version $lastVer */
+        $lastVer = $project->versions->last();
+
+        $this->actingAs($user)
+            ->post('/upload/' . $lastVer->id, ['file' => $upload])
+            ->assertStatus(200);
+
+        /** @var File $icon */
+        $icon = File::where('name', Icon::NAME)->firstOrFail();
+        $this->assertEquals([Icon::SIZE, Icon::SIZE], Icon::dimensions((string) $icon->content));
+        $this->assertTrue($icon->isValidIcon());
+        $this->assertTrue($project->refresh()->hasValidIcon());
+    }
+
+    /**
+     * Only the badge icon is touched; other images are stored as uploaded.
+     */
+    public function testUploadLeavesOtherImagesAlone(): void
+    {
+        $stub = __DIR__ . '/heart.png';
+        $original = (string) file_get_contents($stub);
+        $path = sys_get_temp_dir() . '/' . Str::random(8) . '.png';
+        copy($stub, $path);
+
+        $upload = new UploadedFile($path, 'splash.png', 'image/png', null, true);
+        /** @var User $user */
+        $user = User::factory()->create();
+        $this->be($user);
+        /** @var Project $project */
+        $project = Project::factory()->create();
+        /** @var Version $lastVer */
+        $lastVer = $project->versions->last();
+
+        $this->actingAs($user)
+            ->post('/upload/' . $lastVer->id, ['file' => $upload])
+            ->assertStatus(200);
+
+        /** @var File $stored */
+        $stored = File::where('name', 'splash.png')->firstOrFail();
+        $this->assertEquals($original, $stored->content);
     }
 
 //    public function testUploadIllegalFile(): void

--- a/tests/Unit/IconTest.php
+++ b/tests/Unit/IconTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2017 - 2026 Badge.Team contributors
+// SPDX-License-Identifier: MIT
+
+namespace Tests\Unit;
+
+use App\Support\Icon;
+use Tests\TestCase;
+
+/**
+ * Class IconTest.
+ *
+ * @author annejan@badge.team
+ */
+class IconTest extends TestCase
+{
+    /**
+     * A PNG with an opaque red left half and a fully transparent right half.
+     */
+    private function png(int $width, int $height): string
+    {
+        $this->assertGreaterThan(0, $width);
+        $this->assertGreaterThan(0, $height);
+        $gd = imagecreatetruecolor(max(1, $width), max(1, $height));
+        imagealphablending($gd, false);
+        imagesavealpha($gd, true);
+        imagefill($gd, 0, 0, (int) imagecolorallocatealpha($gd, 0, 0, 0, 127));
+        imagefilledrectangle($gd, 0, 0, (int) ($width / 2) - 1, $height - 1, (int) imagecolorallocate($gd, 255, 0, 0));
+        ob_start();
+        imagepng($gd);
+
+        return (string) ob_get_clean();
+    }
+
+    /**
+     * @return array{0: int, 1: int, 2: int} width, height, alpha of a corner
+     */
+    private function inspect(string $png, int $x, int $y): array
+    {
+        $im = imagecreatefromstring($png);
+        $this->assertNotFalse($im);
+
+        return [imagesx($im), imagesy($im), (imagecolorat($im, $x, $y) >> 24) & 0x7F];
+    }
+
+    public function testNormaliseScalesToBadgeSize(): void
+    {
+        $resized = Icon::normalise($this->png(64, 24));
+
+        $this->assertNotNull($resized);
+        [$width, $height] = $this->inspect($resized, 0, 0);
+        $this->assertEquals(Icon::SIZE, $width);
+        $this->assertEquals(Icon::SIZE, $height);
+    }
+
+    public function testNormaliseKeepsTransparency(): void
+    {
+        $resized = Icon::normalise($this->png(64, 24));
+
+        $this->assertNotNull($resized);
+        // Top right was transparent in the source, and the padding added to
+        // make the image square has to be transparent too.
+        [, , $alpha] = $this->inspect($resized, Icon::SIZE - 1, 0);
+        $this->assertEquals(127, $alpha);
+    }
+
+    public function testNormaliseDoesNotCropTheImage(): void
+    {
+        $resized = Icon::normalise($this->png(64, 24));
+
+        $this->assertNotNull($resized);
+        $im = imagecreatefromstring($resized);
+        $this->assertNotFalse($im);
+        // The red half survives rather than being cropped away.
+        $this->assertGreaterThan(200, (imagecolorat($im, 2, (int) (Icon::SIZE / 2)) >> 16) & 0xFF);
+    }
+
+    public function testNormaliseLeavesACorrectIconAlone(): void
+    {
+        $this->assertNull(Icon::normalise($this->png(Icon::SIZE, Icon::SIZE)));
+    }
+
+    public function testNormaliseIgnoresThingsThatAreNotImages(): void
+    {
+        $this->assertNull(Icon::normalise('import time'));
+        $this->assertNull(Icon::normalise(''));
+    }
+
+    public function testNormaliseHandlesBase64Content(): void
+    {
+        $resized = Icon::normalise(base64_encode($this->png(64, 24)));
+
+        $this->assertNotNull($resized);
+        [$width, $height] = $this->inspect($resized, 0, 0);
+        $this->assertEquals(Icon::SIZE, $width);
+        $this->assertEquals(Icon::SIZE, $height);
+    }
+
+    public function testDimensionsReadsRawAndBase64(): void
+    {
+        $png = $this->png(64, 24);
+
+        $this->assertEquals([64, 24], Icon::dimensions($png));
+        $this->assertEquals([64, 24], Icon::dimensions(base64_encode($png)));
+        $this->assertNull(Icon::dimensions('not an image'));
+    }
+
+    public function testIsIconNameIsCaseInsensitive(): void
+    {
+        $this->assertTrue(Icon::isIconName('icon.png'));
+        $this->assertTrue(Icon::isIconName('Icon.PNG'));
+        $this->assertFalse(Icon::isIconName('icon.py'));
+        $this->assertFalse(Icon::isIconName('splash.png'));
+    }
+}


### PR DESCRIPTION
Closes #126.

266 PHP tests (10 new), phpstan level 8, phpcs and REUSE all pass.

## The bug behind the report

A badge reads `icon.png` at exactly 32×32. Anything else was accepted, stored,
and then **quietly left out of the egg**: `hasValidIcon()` returned false, so
`PublishProject` omitted the `icon` key from `metadata.json` and the badge showed
nothing. Nothing told the user why — which matches the comment on the issue,
where an icon was uploaded and simply did not appear.

Uploading a file called `icon.png` now scales it to 32×32 and stores the result.
It hooks into the model rather than the upload controller, so icons that arrive
with a **git import** get normalised the same way.

## Three details that took measuring

I probed the driver rather than guessing, because two obvious choices are wrong:

| approach | result |
| --- | --- |
| `scale(32, 32)` | keeps transparency, but gives 32×12 — still not a valid icon |
| `cover(32, 32)` | keeps transparency, but **crops** parts of the icon away |
| `contain(32, 32)` | 32×32, but **loses transparency** — pads with opaque black |
| `contain(32, 32, '#00000000')` | 32×32, padding transparent, nothing cropped |

So `contain` with an explicit transparent colour. The colour has to be given as
`#00000000`: the driver rejects the string `'transparent'` with *Unknown color
format*, and omitting it pads opaque — losing exactly the transparency this issue
asks for.

Only `icon.png` is touched, and only when the content actually changed, so other
images are stored byte for byte as uploaded and saving a project does not
re-encode its icon on every write. Both are covered by tests.

## Tidying that came with it

The icon size, the file name, and the decoding of content that may be raw bytes
*or* base64 now live in `App\Support\Icon`. `File::isValidIcon()` uses it, and
`Project::hasValidIcon()` and `PublishProject` use `Icon::NAME` instead of
repeating the literal.

## Not addressed

The issue comment also mentions an error when pressing **Lint**. I could not
reproduce that: the Lint button is already gated on `$file->lintable`, and `png`
is not in `File::$lintables`, so it does not render for an icon. If it is still
happening, a screenshot of the current site would help — it may have been fixed
somewhere between then and now.

The uploaded icon is also still not displayed anywhere in the web UI, which is
probably why "it just shows up as a block square" was confusing. Showing project
icons in the listing is a design change rather than a bug fix, so I have left it
out of this PR — happy to do it if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
