### PR TITLE
Actually allow large uploads

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -36,7 +36,11 @@ jobs:
       with:
         php-version: ${{ matrix.php-versions }}
         extensions: gd, gmp, zip, intl, exif, pcntl, mbstring, fileinfo, xdebug
-        ini-values: "post_max_size=256M"
+        ini-values: "upload_max_filesize=32M, post_max_size=40M, memory_limit=256M"
+    - name: Allow large uploads
+      # A 32 MB file is one big INSERT and the server default is 16 MB. A
+      # service container cannot be given a command, so set it once it is up.
+      run: mariadb -h 127.0.0.1 -P 33306 -uroot -proot -e "SET GLOBAL max_allowed_packet = 67108864;"
     - name: Check PHP Version
       run: php -v
     - name: Install Node.js
@@ -125,6 +129,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+      - name: Allow large uploads
+        run: mariadb -h 127.0.0.1 -P 33306 -uroot -proot -e "SET GLOBAL max_allowed_packet = 67108864;"
       - name: Copy .env
         run: php -r "file_exists('.env') || copy('.env.example', '.env');"
       - name: Install Dependencies

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Allow large uploads
       # A 32 MB file is one big INSERT and the server default is 16 MB. A
       # service container cannot be given a command, so set it once it is up.
-      run: mariadb -h 127.0.0.1 -P 33306 -uroot -proot -e "SET GLOBAL max_allowed_packet = 67108864;"
+      run: docker run --rm --network host mariadb:latest mariadb -h 127.0.0.1 -P 33306 -uroot -proot -e "SET GLOBAL max_allowed_packet = 67108864;"
     - name: Check PHP Version
       run: php -v
     - name: Install Node.js
@@ -130,7 +130,7 @@ jobs:
         with:
           node-version: '22'
       - name: Allow large uploads
-        run: mariadb -h 127.0.0.1 -P 33306 -uroot -proot -e "SET GLOBAL max_allowed_packet = 67108864;"
+        run: docker run --rm --network host mariadb:latest mariadb -h 127.0.0.1 -P 33306 -uroot -proot -e "SET GLOBAL max_allowed_packet = 67108864;"
       - name: Copy .env
         run: php -r "file_exists('.env') || copy('.env.example', '.env');"
       - name: Install Dependencies

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -36,7 +36,9 @@ jobs:
       with:
         php-version: ${{ matrix.php-versions }}
         extensions: gd, gmp, zip, intl, exif, pcntl, mbstring, fileinfo, xdebug
-        ini-values: "upload_max_filesize=32M, post_max_size=40M, memory_limit=256M"
+        # memory_limit is deliberately left at the setup-php default of -1:
+        # pinning it to the runtime value caps phpstan, which needs far more.
+        ini-values: "upload_max_filesize=32M, post_max_size=40M"
     - name: Allow large uploads
       # A 32 MB file is one big INSERT and the server default is 16 MB. A
       # service container cannot be given a command, so set it once it is up.

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,19 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 # which failed later with "not in gzip format" instead of saying what went wrong.
 ENV ZLIB_VERSION=1.2.11
 ENV ZLIB_SHA256=c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
-RUN curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
-        -o zlib.tar.gz "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz" && \
-    echo "${ZLIB_SHA256}  zlib.tar.gz" | sha256sum -c - && \
+# zlib.net regularly refuses CI traffic, so fall back to the SourceForge
+# mirror, which serves a byte identical tarball. Each candidate is only
+# accepted once its checksum matches.
+RUN set -eu; \
+    ok=0; \
+    for url in \
+        "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz" \
+        "https://sourceforge.net/projects/libpng/files/zlib/${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz/download" \
+    ; do \
+        if curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors -o zlib.tar.gz "$url" \
+            && echo "${ZLIB_SHA256}  zlib.tar.gz" | sha256sum -c -; then ok=1; break; fi; \
+    done; \
+    [ "$ok" = 1 ]; \
     tar xf zlib.tar.gz && \
     cd "zlib-${ZLIB_VERSION}" && \
     ./configure && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,15 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install -j"$(nproc)" pdo pdo_mysql mysqli pcntl zip intl gd mbstring gmp exif
 
+# PHP ships with upload_max_filesize=2M and post_max_size=8M, well under the
+# 32 MB the uploader offers. memory_limit has to hold a whole file too, since
+# content is read into a string before it is stored.
+RUN { \
+        echo 'upload_max_filesize = 32M'; \
+        echo 'post_max_size = 40M'; \
+        echo 'memory_limit = 256M'; \
+    } > /usr/local/etc/php/conf.d/hatchery.ini
+
 ENV COMPOSER_HOME=/composer
 ENV COMPOSER_ALLOW_SUPERUSER=1
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer

--- a/README.md
+++ b/README.md
@@ -171,6 +171,23 @@ vendor/bin/phpcs -q --warning-severity=0
 vendor/bin/phpcbf
 ```
 
+## Upload limits
+
+Files are stored in the database, so a large upload has to get past four
+separate limits. The Docker image and `docker-compose.yaml` set all of these;
+a hand rolled deployment needs them too.
+
+| limit | where | needs to be |
+| --- | --- | --- |
+| `upload_max_filesize` | php.ini | at least the ceiling |
+| `post_max_size` | php.ini | a little above it |
+| `memory_limit` | php.ini | file is read into a string |
+| `max_allowed_packet` | MariaDB | one file is one big `INSERT` |
+
+The ceiling itself is `App\Models\File::MAX_UPLOAD_MEGABYTES`, which the
+uploader and the validation rule both read, so raising it is a one line change
+plus matching server settings.
+
 ## Licensing
 
 Hatchery follows the [REUSE](https://reuse.software/spec-3.3/) specification, so

--- a/app/Http/Requests/FileUploadRequest.php
+++ b/app/Http/Requests/FileUploadRequest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use App\Models\File;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 
@@ -35,7 +36,7 @@ class FileUploadRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'file' => 'required|file', //|mimes:'.implode(',', File::$extensions),
+            'file' => 'required|file|max:' . (File::MAX_UPLOAD_MEGABYTES * 1024),
         ];
     }
 }

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -69,6 +69,15 @@ class File extends Model
     use HasFactory;
 
     /**
+     * Largest upload accepted, in megabytes.
+     *
+     * The whole chain has to agree with this: PHP's upload_max_filesize and
+     * post_max_size, MariaDB's max_allowed_packet, and the LONGBLOB the
+     * content is stored in.
+     */
+    public const MAX_UPLOAD_MEGABYTES = 32;
+
+    /**
      * Supported extensions.
      *
      * @var array<string>

--- a/database/migrations/2026_08_14_150000_alter_files_content_mediumblob_to_longblob.php
+++ b/database/migrations/2026_08_14_150000_alter_files_content_mediumblob_to_longblob.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2017 - 2026 Badge.Team contributors
+// SPDX-License-Identifier: MIT
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * MEDIUMBLOB tops out at 16 MiB, which is below the upload limit the
+     * uploader offers, so a large file was accepted and then failed to store.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (Schema::getConnection()->getDriverName() !== 'mysql') {
+            return;
+        }
+
+        DB::statement('ALTER TABLE `files` MODIFY `content` LONGBLOB');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (Schema::getConnection()->getDriverName() !== 'mysql') {
+            return;
+        }
+
+        DB::statement('ALTER TABLE `files` MODIFY `content` MEDIUMBLOB');
+    }
+};

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,6 +37,8 @@ services:
 
   mariadb:
     image: mariadb
+    # A 32 MB file is a single large INSERT; the 16 MB default rejects it.
+    command: --max-allowed-packet=64M
     volumes:
       - ./database/mariadb:/var/lib/mysql
     environment:

--- a/resources/views/projects/partials/files.blade.php
+++ b/resources/views/projects/partials/files.blade.php
@@ -95,7 +95,7 @@
     // window.onload here would replace its handler (and vice versa).
     window.addEventListener('load', function () {
         const uploader = new window.Dropzone("#uploader",{
-            maxFilesize: 32,
+            maxFilesize: {{ \App\Models\File::MAX_UPLOAD_MEGABYTES }},
         });
         const d = document.getElementById("uploader");
         d.className += " dropzone";

--- a/tests/Feature/FilesTest.php
+++ b/tests/Feature/FilesTest.php
@@ -90,6 +90,61 @@ class FilesTest extends TestCase
     }
 
     /**
+     * A file at the advertised ceiling has to survive the whole chain: PHP's
+     * upload limits, MariaDB's max_allowed_packet, and the column it is stored
+     * in, which used to be a 16 MiB MEDIUMBLOB (#127).
+     */
+    public function testUploadLargeFile(): void
+    {
+        $megabytes = 20;
+        $path = sys_get_temp_dir() . '/' . Str::random(8) . '.bin';
+        file_put_contents($path, str_repeat(random_bytes(1024), $megabytes * 1024));
+        $this->assertGreaterThan(16 * 1024 * 1024, filesize($path));
+
+        $upload = new UploadedFile($path, 'big.bin', 'application/octet-stream', null, true);
+        /** @var User $user */
+        $user = User::factory()->create();
+        $this->be($user);
+        /** @var Project $project */
+        $project = Project::factory()->create();
+        /** @var Version $lastVer */
+        $lastVer = $project->versions->last();
+
+        $this->actingAs($user)
+            ->post('/upload/' . $lastVer->id, ['file' => $upload])
+            ->assertStatus(200);
+
+        /** @var File $stored */
+        $stored = File::where('name', 'big.bin')->firstOrFail();
+        $this->assertEquals(filesize($path), strlen((string) $stored->content));
+
+        unlink($path);
+    }
+
+    /**
+     * Beyond the ceiling the user gets a validation error rather than a bare
+     * 413 from the web server.
+     */
+    public function testUploadRejectsFilesOverTheLimit(): void
+    {
+        // fake()->create declares the size without writing the bytes.
+        $upload = UploadedFile::fake()->create('too-big.bin', (File::MAX_UPLOAD_MEGABYTES * 1024) + 1024);
+        /** @var User $user */
+        $user = User::factory()->create();
+        $this->be($user);
+        /** @var Project $project */
+        $project = Project::factory()->create();
+        /** @var Version $lastVer */
+        $lastVer = $project->versions->last();
+
+        $this->actingAs($user)
+            ->post('/upload/' . $lastVer->id, ['file' => $upload])
+            ->assertSessionHasErrors('file');
+
+        $this->assertNull(File::where('name', 'too-big.bin')->first());
+    }
+
+    /**
      * Only the badge icon is touched; other images are stored as uploaded.
      */
     public function testUploadLeavesOtherImagesAlone(): void


### PR DESCRIPTION
Closes #127.

I said last time this looked like php.ini rather than code. **That was wrong** —
I measured it, and there are four separate limits, all sitting below the 32 MB
the uploader has been advertising for years.

268 PHP tests (2 new), phpstan level 8, phpcs, REUSE all pass.

## What was actually blocking it

| limit | was | effect |
| --- | --- | --- |
| `upload_max_filesize` | **2 MB** (PHP default, image set nothing) | anything bigger never reached Laravel |
| `post_max_size` | **8 MB** (PHP default) | same |
| `files.content` column | **MEDIUMBLOB**, 16 MiB | file accepted, then failed to store |
| MariaDB `max_allowed_packet` | **16 MB** | one file is one big `INSERT`; server rejects it |

And there was no server-side size rule at all, so an oversized upload came back
as a bare **413** from the web server instead of a validation error on the field.

Dropzone said 32. Nothing else did.

## The fix

All four raised, plus a `max:` rule. The ceiling is now
`File::MAX_UPLOAD_MEGABYTES`, read by both the uploader widget and the validation
rule, so the client and server cannot drift apart again.

A migration takes `content` to `LONGBLOB`. It is guarded on the mysql driver, so
it is a no-op elsewhere.

## Tests

- uploads **20 MB** — deliberately above the old MEDIUMBLOB ceiling — and asserts
  the bytes survive the round trip
- asserts going over the limit produces a validation error on `file`, not a 413

The oversize test uses `UploadedFile::fake()->create()`, which declares a size
without writing the bytes, so it costs nothing.

## One thing I got wrong on the first attempt

I reached for `MARIADB_EXTRA_FLAGS` in the CI service. **The image ignores it** —
I tested with and without and got 16 MB both times. A service container also
cannot be given a command, so CI raises it with a statement once the server is
up. `docker-compose` *can* take a command, so it passes the flag directly.

Worth flagging because it fails silently: the workflow would have looked correct
and the limit would still have been 16 MB.

## Deployment

`README.md` now lists all four, because **two of them live outside this
repository**. The Docker image and `docker-compose.yaml` set everything, but a
hand rolled deployment needs `max_allowed_packet` raised on its own MariaDB or
large uploads will still fail there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
