### PR TITLE
Pin that exceptions still reach Sentry

### DIFF
--- a/tests/Feature/ErrorReportingTest.php
+++ b/tests/Feature/ErrorReportingTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2017 - 2026 Badge.Team contributors
+// SPDX-License-Identifier: MIT
+
+namespace Tests\Feature;
+
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Sentry\ClientBuilder;
+use Sentry\Options;
+use Sentry\SentrySdk;
+use Tests\Support\RecordingTransport;
+use Tests\TestCase;
+
+/**
+ * Class ErrorReportingTest.
+ *
+ * Exceptions have to keep reaching Sentry. Nothing else in the test suite
+ * notices if that stops working, and a site whose errors go nowhere is a site
+ * whose bugs cannot be diagnosed, so this pins the wiring in bootstrap/app.php.
+ *
+ * @author annejan@badge.team
+ */
+class ErrorReportingTest extends TestCase
+{
+    /**
+     * Point the SDK at a transport that keeps what it is given.
+     *
+     * @return RecordingTransport
+     */
+    private function recordingTransport(): RecordingTransport
+    {
+        $transport = new RecordingTransport();
+
+        $client = (new ClientBuilder(new Options(['dsn' => 'https://key@example.com/1'])))
+            ->setTransport($transport)
+            ->getClient();
+
+        SentrySdk::getCurrentHub()->bindClient($client);
+
+        return $transport;
+    }
+
+    public function testReportedExceptionsReachSentry(): void
+    {
+        $transport = $this->recordingTransport();
+
+        app(ExceptionHandler::class)->report(new \RuntimeException('reporting probe'));
+
+        $this->assertCount(1, $transport->events);
+        $exceptions = $transport->events[0]->getExceptions();
+        $this->assertNotEmpty($exceptions);
+        $this->assertEquals('reporting probe', $exceptions[0]->getValue());
+    }
+
+    /**
+     * The handler skips the noisy ones, so a 404 or a failed validation does
+     * not drown out the reports that matter.
+     */
+    public function testExpectedExceptionsAreNotReported(): void
+    {
+        $transport = $this->recordingTransport();
+
+        app(ExceptionHandler::class)->report(new \Illuminate\Auth\AuthenticationException());
+        app(ExceptionHandler::class)->report(
+            new \Illuminate\Database\Eloquent\ModelNotFoundException()
+        );
+
+        $this->assertCount(0, $transport->events);
+    }
+}

--- a/tests/Support/RecordingTransport.php
+++ b/tests/Support/RecordingTransport.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2017 - 2026 Badge.Team contributors
+// SPDX-License-Identifier: MIT
+
+namespace Tests\Support;
+
+use Sentry\Event;
+use Sentry\Transport\Result;
+use Sentry\Transport\ResultStatus;
+use Sentry\Transport\TransportInterface;
+
+/**
+ * A Sentry transport that keeps events instead of sending them.
+ *
+ * @author annejan@badge.team
+ */
+class RecordingTransport implements TransportInterface
+{
+    /** @var array<int, Event> */
+    public array $events = [];
+
+    /**
+     * @param Event $event
+     *
+     * @return Result
+     */
+    public function send(Event $event): Result
+    {
+        $this->events[] = $event;
+
+        return new Result(ResultStatus::success(), $event);
+    }
+
+    /**
+     * @param int|null $timeout
+     *
+     * @return Result
+     */
+    public function close(?int $timeout = null): Result
+    {
+        return new Result(ResultStatus::success());
+    }
+}


### PR DESCRIPTION
Small, but it protects the thing that makes every other bug diagnosable.

## Why

I keep asking for a Sentry stack trace to make progress on #163, #160 and #156.
Before asking again, I checked whether Sentry still reports at all after the
Laravel 13 upgrade — because if I had broken it, that would be my regression and
the reason there is nothing to look at.

**It works.** I pointed the SDK at a local listener and reported an exception
through the real exception handler:

```
dsn configured: true
sentry bound  : true
reported via handler
flushed

SENTRY REQUESTS RECEIVED: 1 ['/api/1/envelope/']
```

So the silence is not a broken integration. Either `SENTRY_LARAVEL_DSN` is unset
on the deployment, or nobody has looked.

## What this adds

Error reporting is the one thing nothing else notices when it breaks. The
Laravel 11 skeleton moved it from `Handler::report()` to
`Integration::handles($exceptions)` in `bootstrap/app.php` during the upgrade —
and if that single line ever goes missing, the whole suite stays green while
every error on the site quietly goes nowhere.

Two tests:

- a reported exception reaches the transport
- the ones the handler is told to ignore (auth failures, missing models) do not,
  so the signal does not drown in noise

I checked the first is not vacuous: commenting out `Integration::handles()` in
`bootstrap/app.php` fails it.

The transport double lives in `tests/Support` rather than being an anonymous
class, because an anonymous class hides its own properties from phpstan.

270 tests, phpstan level 8, phpcs and REUSE all pass.

## Still the ask

If `SENTRY_LARAVEL_DSN` is set in production, one stack trace from a 419 or from
the password reset 500 turns #163, #160 and #156 from guesswork into ordinary
fixes. If it is *not* set, that is a one line change with a large payoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
