### PR TITLE
Report test coverage to Qlty

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -35,7 +35,8 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
-        extensions: gd, gmp, zip, intl, exif, pcntl, mbstring, fileinfo, xdebug
+        extensions: gd, gmp, zip, intl, exif, pcntl, mbstring, fileinfo
+        coverage: pcov
         # memory_limit is deliberately left at the setup-php default of -1:
         # pinning it to the runtime value caps phpstan, which needs far more.
         ini-values: "upload_max_filesize=32M, post_max_size=40M"
@@ -96,7 +97,19 @@ jobs:
         DB_TEST_DATABASE: badge
         DB_TEST_USERNAME: root
         DB_TEST_PASSWORD: root
-      run: vendor/bin/pest
+      run: vendor/bin/pest --coverage-clover coverage/clover.xml
+    - name: Report coverage
+      # One upload is enough; the matrix would otherwise send the same numbers
+      # twice. Pull requests from forks cannot see the token, so skip those
+      # rather than fail them; pushes to main still report.
+      if: >-
+        matrix.php-versions == '8.4' &&
+        (github.event_name != 'pull_request' ||
+         github.event.pull_request.head.repo.full_name == github.repository)
+      uses: qltysh/qlty-action/coverage@v2
+      with:
+        token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+        files: coverage/clover.xml
 
   browser-tests:
     name: Browser tests


### PR DESCRIPTION
Adds the coverage upload you pasted, wired into the existing test job.

## What it does

Pest writes a clover report, `qltysh/qlty-action/coverage@v2` uploads it.

Coverage comes from **pcov rather than xdebug** — it is all that is needed for
line coverage and costs a fraction of the time. The full suite runs in about
**11 seconds** with it, so this does not slow CI down.

Two guards on the upload step:

- **only the 8.4 leg uploads** — the matrix runs 8.4 and 8.5 and would otherwise
  send the same numbers twice
- **fork pull requests skip it** rather than fail, since they cannot see the
  token. Pushes to `main` still report.

Current coverage is **96.4%** of 1480 statements, 67 files.

## Verified locally

I added pcov to my dev image and ran it end to end rather than trusting the
flags: `--coverage-clover` alone does write the file (no `--coverage` needed),
and the output parses as valid clover with all 67 files present.

## You need to do one thing

The token belongs in a repository secret, not in the repo:

```bash
gh secret set QLTY_COVERAGE_TOKEN --repo badgeteam/Hatchery
# paste the token when prompted
```

Until that exists the step will fail on `main`. **I have not stored the token
anywhere** — and since it was pasted into a chat transcript, rotating it in Qlty
afterwards is the cautious move.

## Not done here: the badges

Three of the badges in the README are stale and I left them alone rather than
guess:

| badge | state |
| --- | --- |
| Code Climate ×2 | Code Climate Quality is the thing Qlty replaced |
| Codacy | nothing has reported since `codacy/coverage` was dropped in the upgrade |
| Codecov | still renders 97%, but that number is from 2022, and it points at branch `master` which does not exist |

Replacing them with Qlty badges needs the project id from your Qlty settings,
which I do not have. Paste the badge markdown Qlty gives you and I will swap them
in, or say the word and I will simply delete the three dead ones.

## Follow-up worth considering

`@vitest/coverage-v8` is already a dependency and `npm run coverage` works, so
the JavaScript could report too. It is only a few modules today, so I left it out
rather than pad the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
