### PR TITLE
Do not let a failed coverage upload pass as success

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -98,6 +98,9 @@ jobs:
         DB_TEST_USERNAME: root
         DB_TEST_PASSWORD: root
       run: vendor/bin/pest --coverage-clover coverage/clover.xml
+    - name: Check the coverage report exists
+      if: matrix.php-versions == '8.4'
+      run: test -s coverage/clover.xml && grep -q '<coverage' coverage/clover.xml
     - name: Report coverage
       # One upload is enough; the matrix would otherwise send the same numbers
       # twice. Pull requests from forks cannot see the token, so skip those
@@ -110,6 +113,12 @@ jobs:
       with:
         token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
         files: coverage/clover.xml
+        # The action defaults to swallowing its own errors. The first run here
+        # went green while uploading nothing, logging "Either 'oidc' or 'token'
+        # must be provided", because the secret did not exist yet. An upload
+        # that quietly does nothing is worse than a red build: the number just
+        # stops moving and nobody notices.
+        skip-errors: false
 
   browser-tests:
     name: Browser tests


### PR DESCRIPTION
Follow-up to #195. Small, but it closes a hole that had already bitten once.

## What happened

The first run of the coverage step went **green while uploading nothing**:

```
##[error]Error validating action input:
##[error]Either 'oidc' or 'token' must be provided.
```

The secret did not exist yet, and `qlty-action` defaults to `skip-errors: true`,
so it logged the error and exited zero. CI was entirely green.

It works now that you have set the secret — main reports **97.31%**, 67 files,
upload confirmed. But the same silence returns the day that token is rotated or
revoked, and the only symptom is a coverage number that quietly stops moving.
That is the least noticeable kind of broken.

## The change

- `skip-errors: false`, so a failed upload fails the job
- a check that `coverage/clover.xml` exists and is really a clover report before
  trying to send it, so a missing report fails at the step that should have
  produced it rather than at the far end

The trade-off is that a Qlty outage would redden the build. I think that is the
right way round for something whose entire job is to report a number — a red
build gets fixed, a silently missing upload does not. Easy to flip back if it
proves annoying in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
