### PR TITLE
Ship an example websocket server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,40 @@ You'll need a be running [Laravel Horizon](https://laravel.com/docs/13.x/horizon
 For the websocket server.
 
 ```bash
+cp laravel-echo-server.json.example laravel-echo-server.json
 laravel-echo-server start
 ```
+
+`laravel-echo-server.json` is deliberately not in the repository or the release
+tarball: it holds host specific paths. Together with `.env` it is one of the two
+files a deployment has to carry across by hand, and losing it is silent — the
+site keeps working, only live updates stop.
+
+Two settings need attention:
+
+-   `keyPrefix` must match the prefix Laravel puts on its Redis keys, or the
+    server subscribes to a pattern nothing publishes to. That prefix defaults to
+    `Str::slug(APP_NAME) . '-database-'`, so it changes if `APP_NAME` does.
+    Ask the application rather than guessing:
+
+    ```bash
+    php artisan tinker --execute='echo config("database.redis.options.prefix"), PHP_EOL;'
+    ```
+
+-   The `ssl*Path` entries are read once at startup, so the server keeps serving
+    the certificate it started with. Restart it after a renewal, or it will
+    eventually be offering an expired one.
+
+To check a running server, from anywhere:
+
+```bash
+curl 'https://hatchery.example.com:6001/socket.io/?EIO=4&transport=polling'
+```
+
+A session id comes back when it is healthy. `"devMode": true` logs every channel
+it sees, which is the quickest way to confirm events are arriving — note that it
+prints the channel name before the key prefix is stripped, so the prefix showing
+up there is expected and not a misconfiguration.
 
 ### Running the development server locally
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -28,6 +28,7 @@ SPDX-License-Identifier = "MIT"
 path = [
     "composer.json",
     "composer.lock",
+    "laravel-echo-server.json.example",
     "package.json",
     "package-lock.json",
     "public/manifest.json",


### PR DESCRIPTION
Follow-up to #200, which was caused by this gap.

`laravel-echo-server.json` is in neither the repository nor the release tarball —
`package.yml` tars an explicit list of directories, so the file is destroyed by
any deploy that replaces the tree. The failure mode is silent: the site keeps
serving, only live updates stop. Both production instances ended up without a
websocket server this way.

It can't just be added to the release, because it holds host-specific paths
(certificates, auth host). So this ships an example to copy, and documents the
parts that are easy to get wrong:

- **`keyPrefix` must match Laravel's Redis prefix** or the subscriber listens on
  a pattern nothing publishes to. It defaults to
  `Str::slug(APP_NAME) . '-database-'`, so it moves when `APP_NAME` does — the
  README tells you to ask `config("database.redis.options.prefix")` rather than
  guess.
- **`ssl*Path` is read once at startup.** A renewed certificate doesn't reach a
  running server; it has to be restarted. That is precisely what was reported in
  #163 back in 2022 as an expired websocket certificate.
- A one-line `curl` that says whether the server is alive.
- A note that `devMode` logs the channel name *before* the key prefix is
  stripped, so seeing the prefix there is expected. It looks like a
  misconfiguration and isn't — I went and read `RedisSubscriber` to be sure.

REUSE compliant (362/362 — JSON can't carry a header, so it's annotated in
`REUSE.toml` with the other manifests), markdownlint clean, valid JSON.
