### PR TITLE
Actually add the websocket config example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ _ide_helper.php
 /storage/api-docs
 /database/mariadb
 laravel-echo-server.*
+!laravel-echo-server.json.example
 /public/sw.js.LICENSE.txt
 /resources/views/vendor

--- a/laravel-echo-server.json.example
+++ b/laravel-echo-server.json.example
@@ -1,0 +1,33 @@
+{
+	"authHost": "https://hatchery.example.com",
+	"authEndpoint": "/broadcasting/auth",
+	"clients": [],
+	"database": "redis",
+	"databaseConfig": {
+		"redis": {
+			"host": "127.0.0.1",
+			"port": 6379,
+			"keyPrefix": "hatchery-database-"
+		}
+	},
+	"devMode": false,
+	"host": null,
+	"port": "6001",
+	"protocol": "https",
+	"socketio": {},
+	"secureOptions": 67108864,
+	"sslCertPath": "/etc/letsencrypt/live/hatchery.example.com/cert.pem",
+	"sslKeyPath": "/etc/letsencrypt/live/hatchery.example.com/privkey.pem",
+	"sslCertChainPath": "/etc/letsencrypt/live/hatchery.example.com/chain.pem",
+	"sslPassphrase": "",
+	"subscribers": {
+		"http": true,
+		"redis": true
+	},
+	"apiOriginAllow": {
+		"allowCors": false,
+		"allowOrigin": "",
+		"allowMethods": "",
+		"allowHeaders": ""
+	}
+}


### PR DESCRIPTION
Follow-up to #201, which merged without the file it was about.

`.gitignore` carries `laravel-echo-server.*`, which matches
`laravel-echo-server.json.example` as well as the real config. `git add -A`
skipped it silently, so #201 shipped the README section and the `REUSE.toml`
annotation but not the example itself — `main` currently tells you to
`cp laravel-echo-server.json.example laravel-echo-server.json` for a file that
does not exist.

This adds `!laravel-echo-server.json.example` as an exception, and the file.

My mistake — I caught it after #201 had already been merged, so it needs its own
PR rather than a force-push.

REUSE still passes (the annotation landed with #201), valid JSON.
