### PR TITLE
Attach the release tarball to the release

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -8,6 +8,9 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: write
+
 jobs:
   build:
 
@@ -52,3 +55,8 @@ jobs:
         with:
           name: Hatchery_${{ env.RELEASE_VERSION }}
           path: Hatchery_${{ env.RELEASE_VERSION }}.tar.gz
+      - name: Attach the tar to the release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: Hatchery_${{ env.RELEASE_VERSION }}.tar.gz
+          fail_on_unmatched_files: true


### PR DESCRIPTION
The tag build tars up a release and then only calls `actions/upload-artifact`,
which stores it as a **workflow artifact** — it expires, and it is only reachable
from the Actions run page. Nothing ever put it on the release itself.

That is why v1.0.0's `Hatchery_v1.0.0.tar.gz` had to be attached by hand. Worse,
a release cut without remembering that step looks complete while offering nothing
to download.

`softprops/action-gh-release@v2` attaches the tarball to the release for the tag,
creating the release if the tag was pushed without one. The artifact upload stays,
since it is still useful for inspecting a build that failed later.

`fail_on_unmatched_files: true` is deliberate: if the tar step is ever renamed,
the build should fail rather than quietly publish a release with no asset.

Needs `permissions: contents: write`, which the workflow did not have.

Worth merging before v1.0.1 is tagged, so that release publishes its own asset.
