### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hatchery",
-  "version": "1.1.1",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hatchery",
-      "version": "1.1.1",
+      "version": "1.0.1",
       "dependencies": {
         "@codemirror/commands": "^6.10.4",
         "@codemirror/lang-javascript": "^6.2.5",
@@ -45,6 +45,9 @@
         "sass": "^1.102.0",
         "vite": "^8.2.1",
         "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hatchery",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "badge.team Hatchery",
   "author": "Anne Jan Brouwer <brouwer@annejan.com>",
   "private": false,


### PR DESCRIPTION
Version bump for the v1.0.1 release.

`main` is verified green as of 991c305: 290 PHP tests, 26 JavaScript tests, phpstan level 8, phpcs and REUSE all clean.

Contents since v1.0.0:

| PR | |
| --- | --- |
| #195, #196 | test coverage reported to Qlty, and a failed upload no longer passes as success |
| #197 | JavaScript coverage, README brought in line with reality |
| #198 | declare the PHP extensions we actually use, and turn the runtime platform check on |
| #201, #203 | ship an example websocket server config, so it stops being lost on deploy |
| #202 | replace Dark Sky with Open-Meteo, fixing `/weather` (#199) |
| #204 | attach the release tarball to the release |

#204 matters for this one specifically: v1.0.1 will be the first release to publish its own asset instead of needing a manual upload.