### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hatchery",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hatchery",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@codemirror/commands": "^6.10.4",
         "@codemirror/lang-javascript": "^6.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hatchery",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "badge.team Hatchery",
   "author": "Anne Jan Brouwer <brouwer@annejan.com>",
   "private": false,


### PR DESCRIPTION
1.0.1 shipped the Content-Length regression (#206) that stopped every MCH2022 badge from reaching the Hatchery, so this is worth a release of its own.

Only the root version changes. The dependency entries in `package-lock.json` that happen to sit at `1.0.1` — `@humanwhocodes/module-importer`, `@rolldown/pluginutils` and friends — are left alone; a blanket replace would have silently rewritten those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142DuVFXpWnjeQhZzT3N3nC